### PR TITLE
fix HIDReport write size

### DIFF
--- a/libuuu/hidreport.h
+++ b/libuuu/hidreport.h
@@ -128,7 +128,7 @@ public:
 
 			memcpy(m_out_buff.data() + m_size_payload, buff + off, s);
 
-			int ret = m_pdev->write(m_out_buff.data(), report_id == 1? s + m_size_payload: m_size_out + m_size_payload);
+			int ret = m_pdev->write(m_out_buff.data(), s + m_size_payload);
 
 			if ( ret < 0)
 				return -1;


### PR DESCRIPTION
The JumpCmd, clears the DCD vector in the IVT, but instead of writing one single word,
HIDReport.write() writes a full report of m_size_out Bytes for report_id !=1,
overwriting part oft the image and invalidating the HAB signature. Boot fails in closed
configuration.